### PR TITLE
refactor: make event prevention configurable

### DIFF
--- a/src/app/pinch-zoom/pinch-zoom.component.ts
+++ b/src/app/pinch-zoom/pinch-zoom.component.ts
@@ -52,6 +52,7 @@ export class PinchZoomComponent implements OnInit {
     @Input('auto-zoom-out') autoZoomOut = false;
     @Input('limit-zoom') limitZoom: number;
     @Input('disabled') disabled: boolean = false;
+    @Input('allow-scroll') allowScroll: boolean = false;
 
     @Output() events: EventEmitter<any> = new EventEmitter<any>();
 
@@ -273,7 +274,9 @@ export class PinchZoomComponent implements OnInit {
     }
 
     handleSwipe(event): void {
-        event.preventDefault();
+        if (!this.allowScroll) {
+            event.preventDefault();
+        }
 
         if (!this.eventType) {
             this.startX = event.touches[0].clientX - this.elementPosition.left;


### PR DESCRIPTION
https://github.com/drozhzhin-n-e/ngx-pinch-zoom/issues/33

With this PR, you can add an allow-scroll input to the pinch-zoom component and ensure that your image will scroll normally and you won't be restricted before the end of the image.

```html
<pinch-zoom [allow-scroll]="true"></pinch-zoom>
```